### PR TITLE
set admin_badge privs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -97,8 +97,30 @@ if (minetest.get_modpath("3d_armor")) then
 		inventory_image = "tps_items_admin_badge_icon.png",
 		armor_groups = {fleshy=100},
 		groups = {armor_torso=1000, armor_heal=1000, armor_use=0, not_in_creative_inventory=1},
+
 		on_drop = function(itemstack, dropper, pos)
 			return
+		end,
+
+		on_equip = function(player)
+			local name = player:get_player_name()
+			local privs = minetest.get_player_privs(name)
+			privs.no_knockback = true
+			minetest.set_player_privs(name, privs)
+		end,
+
+		on_unequip = function(player)
+			local name = player:get_player_name()
+			local privs = minetest.get_player_privs(name)
+			privs.no_knockback = false
+			minetest.set_player_privs(name, privs)
+		end,
+
+		on_destroy = function(player)
+			local name = player:get_player_name()
+			local privs = minetest.get_player_privs(name)
+			privs.no_knockback = false
+			minetest.set_player_privs(name, privs)
 		end,
 	})
 	minetest.register_alias("adminbadge","tps_items:admin_badge")


### PR DESCRIPTION
This *should* set the 'no_knockback' privelage when you put on and take off admin badge, also when it's destroyed.